### PR TITLE
Fix token refresh to retain tenant info

### DIFF
--- a/XeroNetStandardApp/Controllers/BaseXeroOAuth2Controller.cs
+++ b/XeroNetStandardApp/Controllers/BaseXeroOAuth2Controller.cs
@@ -115,6 +115,11 @@ namespace XeroNetStandardApp.Controllers
                 var client = new XeroClient(_xeroConfig.Value); // uses default HttpClient internally
                 var newToken = (XeroOAuth2Token)await client.RefreshAccessTokenAsync(token);
 
+                // Xero's refresh endpoint does not return tenant or ID token
+                // information, so preserve these from the previous token.
+                newToken.Tenants = token.Tenants;
+                newToken.IdToken = token.IdToken;
+
                 _tokenService.StoreToken(newToken);
                 _logger.LogInformation("Xero token refreshed successfully (expires {Expiry}).", newToken.ExpiresAtUtc);
 

--- a/XeroNetStandardApp/Services/XeroRawIngestService.cs
+++ b/XeroNetStandardApp/Services/XeroRawIngestService.cs
@@ -152,7 +152,11 @@ namespace XeroNetStandardApp.Services
             var expiresIn = JsonDocument.Parse(json).RootElement.GetProperty("expires_in").GetInt32();
             refreshed.ExpiresAtUtc = DateTime.UtcNow.AddSeconds(expiresIn);
 
-            // NB: Xero rotates the refresh-token too
+            // NB: Xero rotates the refresh-token too, but does not return tenant
+            // or ID token information. Preserve these from the previous token.
+            refreshed.Tenants = current.Tenants;
+            refreshed.IdToken = current.IdToken;
+
             _tokenService.StoreToken(refreshed);
 
             _log.LogInformation("Token refreshed, now expires {Expiry:u}", refreshed.ExpiresAtUtc);


### PR DESCRIPTION
## Summary
- keep Tenants and IdToken when refreshing tokens

## Testing
- `dotnet build RoadmApp.sln -c Release` *(fails: `dotnet` not found)*