### PR TITLE
Configure Jest and React Testing Library

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js', 'jsx']
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,20 @@
   "name": "RoadmApp",
   "version": "1.0.0",
   "description": "",
-  "scripts": {},
-  "dependencies": {},
-  "devDependencies": {}
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.0",
+    "@babel/preset-env": "^7.21.0",
+    "@babel/preset-react": "^7.18.6",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.6.1",
+    "jest": "^29.6.1"
+  }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/SampleComponent.jsx
+++ b/src/SampleComponent.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function SampleComponent() {
+  return <div>Hello Jest</div>;
+}

--- a/src/__tests__/SampleComponent.test.jsx
+++ b/src/__tests__/SampleComponent.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import SampleComponent from '../SampleComponent';
+
+test('renders greeting', () => {
+  render(<SampleComponent />);
+  expect(screen.getByText(/hello jest/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library configs
- add Babel configuration
- create a sample React component and test
- update package.json with testing dependencies

## Testing
- `npm test --silent` *(fails: jest: not found)*