### PR TITLE
Add navigation buttons on manual load page

### DIFF
--- a/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
+++ b/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
@@ -5,6 +5,15 @@
 
 <h2>Endpoint Control Panel</h2>
 
+<div class="mb-3">
+    <a class="btn btn-secondary btn-sm me-2" asp-controller="Authorization" asp-action="Index">
+        Add Organisation
+    </a>
+    <a class="btn btn-secondary btn-sm" asp-controller="IdentityInfo" asp-action="Index">
+        Manual Data Load
+    </a>
+</div>
+
 <form asp-action="BulkTrigger" method="post">
 
     <table class="table table-sm table-striped">


### PR DESCRIPTION
## Summary
- add Add Organisation & Manual Data Load buttons above IdentityInfo table

## Testing
- `npm test` *(fails: jest not found)*
- `dotnet test` *(fails: command not found)*