### PR TITLE
Add polling config page and schema

### DIFF
--- a/XeroNetStandardApp/Controllers/PollingConfigController.cs
+++ b/XeroNetStandardApp/Controllers/PollingConfigController.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using XeroNetStandardApp.Models;
+using XeroNetStandardApp.Services;
+
+namespace XeroNetStandardApp.Controllers;
+
+public class PollingConfigController : Controller
+{
+    private readonly TokenService _tokenService;
+
+    public PollingConfigController(TokenService tokenService)
+    {
+        _tokenService = tokenService;
+    }
+
+    // GET /PollingConfig
+    public IActionResult Index()
+    {
+        var token = _tokenService.RetrieveToken();
+        if (token == null) return RedirectToAction("Index", "Authorization");
+
+        var model = new PollingConfigViewModel
+        {
+            Tenants = token.Tenants.Select(t => new OrgTenant
+            {
+                TenantId = t.TenantId.ToString(),
+                OrgName = t.TenantName
+            }).ToList(),
+            AccountingEndpoints = new()
+            {
+                new EndpointOption { Key = "contacts", DisplayName = "Contacts" },
+                new EndpointOption { Key = "invoices", DisplayName = "Invoices" },
+                new EndpointOption { Key = "payments", DisplayName = "Payments" }
+            },
+            AssetsEndpoints = new()
+            {
+                new EndpointOption { Key = "assets", DisplayName = "Assets" },
+                new EndpointOption { Key = "assettypes", DisplayName = "Asset Types" }
+            }
+        };
+
+        return View(model);
+    }
+}

--- a/XeroNetStandardApp/Models/PollingConfigViewModel.cs
+++ b/XeroNetStandardApp/Models/PollingConfigViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace XeroNetStandardApp.Models;
+
+public class PollingConfigViewModel
+{
+    public List<OrgTenant> Tenants { get; set; } = new();
+    public List<EndpointOption> AccountingEndpoints { get; set; } = new();
+    public List<EndpointOption> AssetsEndpoints { get; set; } = new();
+}

--- a/XeroNetStandardApp/Views/Home/Index.cshtml
+++ b/XeroNetStandardApp/Views/Home/Index.cshtml
@@ -22,8 +22,11 @@
             <a class="btn btn-secondary btn-sm me-2" asp-controller="Authorization" asp-action="Index">
                 Add Organisation
             </a>
-            <a class="btn btn-secondary btn-sm" asp-controller="IdentityInfo" asp-action="Index">
+            <a class="btn btn-secondary btn-sm me-2" asp-controller="IdentityInfo" asp-action="Index">
                 Manual Data Load
+            </a>
+            <a class="btn btn-secondary btn-sm" asp-controller="PollingConfig" asp-action="Index">
+                Polling Settings
             </a>
         </div>
         @if (Model.Tenants.Count == 0)

--- a/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
+++ b/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
@@ -1,0 +1,54 @@
+@model XeroNetStandardApp.Models.PollingConfigViewModel
+@{
+    ViewData["Title"] = "Polling Configuration";
+}
+
+<h2>Polling Configuration</h2>
+
+@foreach (var tenant in Model.Tenants)
+{
+    <h4>@tenant.OrgName</h4>
+    <table class="table table-sm table-bordered">
+        <thead>
+            <tr>
+                <th>Endpoint</th>
+                <th>Frequency</th>
+                <th>Time</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var ep in Model.AccountingEndpoints)
+            {
+                <tr>
+                    <td>Accounting – @ep.DisplayName</td>
+                    <td>
+                        <select class="form-select form-select-sm" name="freq[@tenant.TenantId][@ep.Key]">
+                            <option>Off</option>
+                            <option>Daily</option>
+                            <option>Weekly</option>
+                        </select>
+                    </td>
+                    <td>
+                        <input type="time" class="form-control form-control-sm" name="time[@tenant.TenantId][@ep.Key]" />
+                    </td>
+                </tr>
+            }
+            @foreach (var ep in Model.AssetsEndpoints)
+            {
+                <tr>
+                    <td>Assets – @ep.DisplayName</td>
+                    <td>
+                        <select class="form-select form-select-sm" name="freq[@tenant.TenantId][@ep.Key]">
+                            <option>Off</option>
+                            <option>Daily</option>
+                            <option>Weekly</option>
+                        </select>
+                    </td>
+                    <td>
+                        <input type="time" class="form-control form-control-sm" name="time[@tenant.TenantId][@ep.Key]" />
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/docs/polling_config.sql
+++ b/docs/polling_config.sql
@@ -1,0 +1,11 @@
+-- Configuration table for tenant polling schedules
+CREATE TYPE utils.poll_frequency AS ENUM ('OFF','DAILY','WEEKLY');
+
+CREATE TABLE utils.polling_config (
+    tenant_id     TEXT       NOT NULL,
+    endpoint_key  TEXT       NOT NULL,
+    frequency     utils.poll_frequency NOT NULL DEFAULT 'OFF',
+    run_time      TIME NOT NULL DEFAULT '00:00',
+    PRIMARY KEY (tenant_id, endpoint_key)
+);
+


### PR DESCRIPTION
## Summary
- create `PollingConfigController` with an Index route
- add `PollingConfigViewModel`
- add `PollingConfig/Index` page with tenant sections and dropdowns
- link to the new page from the home screen
- provide DDL for storing polling configuration

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*
- `npm test --silent` *(fails: `jest: not found`)*