### PR TITLE
Fix home page last-updated timestamp updates

### DIFF
--- a/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
@@ -8,10 +8,10 @@ namespace XeroNetStandardApp.Tests.Helpers
     {
         public List<(string Tenant, string Endpoint)> Calls { get; } = new();
 
-        public Task RunEndpointAsync(string tenantId, string endpointKey)
+        public Task<int> RunEndpointAsync(string tenantId, string endpointKey)
         {
             Calls.Add((tenantId, endpointKey));
-            return Task.CompletedTask;
+            return Task.FromResult(0);
         }
     }
 }

--- a/XeroNetStandardApp.Tests/PollingServiceTests.cs
+++ b/XeroNetStandardApp.Tests/PollingServiceTests.cs
@@ -37,9 +37,10 @@ namespace XeroNetStandardApp.Tests
             });
 
             var svc = new PollingService(tokenService, raw, NullLogger<PollingService>.Instance);
-            await svc.RunEndpointAsync("123", "assets");
+            var rows = await svc.RunEndpointAsync("123", "assets");
 
             Assert.Equal(("123", "assets"), raw.LastCall);
+            Assert.Equal(0, rows);
         }
     }
 }

--- a/XeroNetStandardApp/Controllers/RawSyncController.cs
+++ b/XeroNetStandardApp/Controllers/RawSyncController.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using XeroNetStandardApp.Services;
@@ -39,8 +40,12 @@ namespace XeroNetStandardApp.Controllers
                 return RedirectToAction("Index", "IdentityInfo");
             }
 
+            var totalRows = 0;
             foreach (var ep in selectedEndpoints)
-                await _pollingService.RunEndpointAsync(tenantId, ep);
+                totalRows += await _pollingService.RunEndpointAsync(tenantId, ep);
+
+            if (totalRows > 0)
+                TempData[$"PollLast_{tenantId}"] = DateTime.UtcNow.ToString("o");
 
             TempData["Message"] = "Polling triggered.";
             return RedirectToAction("Index", "IdentityInfo");

--- a/XeroNetStandardApp/Services/IPollingService.cs
+++ b/XeroNetStandardApp/Services/IPollingService.cs
@@ -4,6 +4,10 @@ namespace XeroNetStandardApp.Services
 {
     public interface IPollingService
     {
-        Task RunEndpointAsync(string tenantId, string endpointKey);
+        /// <summary>
+        /// Runs the ingest pipeline for a specific endpoint and returns the
+        /// number of rows inserted.
+        /// </summary>
+        Task<int> RunEndpointAsync(string tenantId, string endpointKey);
     }
 }

--- a/XeroNetStandardApp/Services/PollingService.cs
+++ b/XeroNetStandardApp/Services/PollingService.cs
@@ -21,15 +21,16 @@ namespace XeroNetStandardApp.Services
             _log = log;
         }
 
-        public async Task RunEndpointAsync(string tenantId, string endpointKey)
+        public async Task<int> RunEndpointAsync(string tenantId, string endpointKey)
         {
             XeroOAuth2Token? tok = _tokenService.RetrieveToken();
             if (tok == null || string.IsNullOrEmpty(tok.AccessToken))
                 throw new InvalidOperationException("No valid Xero token on file.");
 
-            await _ingestSvc.RunOnceAsync(tenantId, endpointKey);
+            var rows = await _ingestSvc.RunOnceAsync(tenantId, endpointKey);
 
             _log.LogInformation("Polled {Endpoint} for tenant {Tenant}", endpointKey, tenantId);
+            return rows;
         }
     }
 }

--- a/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
+++ b/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
@@ -90,4 +90,15 @@
             });
         });
     </script>
+    @if (TempData.Keys.Any(k => k.StartsWith("PollLast_")))
+    {
+        <script>
+            @foreach (var key in TempData.Keys.Where(k => k.StartsWith("PollLast_")))
+            {
+                var tid = key.Substring("PollLast_".Length);
+                var val = TempData[key];
+                <text>localStorage.setItem('pollLast_@tid', '@val');</text>
+            }
+        </script>
+    }
 }

--- a/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
+++ b/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
@@ -176,7 +176,6 @@
                     };
 
                     localStorage.setItem(`pollConf_${tid}`, JSON.stringify(cfg));
-                    localStorage.setItem(`pollLast_${tid}`, new Date().toISOString());
                 });
             });
 


### PR DESCRIPTION
## Summary
- avoid timestamp updates when saving polling schedule
- return inserted row count from polling service
- surface inserted row counts through controllers
- store poll timestamps in `TempData`
- sync browser localStorage using TempData
- update tests for new polling service API

## Testing
- `npm test` *(fails: `jest` not found)*
- `dotnet test` *(fails: command not found)*