### PR TITLE
Fix last update timestamp handling

### DIFF
--- a/XeroNetStandardApp/Views/Home/Index.cshtml
+++ b/XeroNetStandardApp/Views/Home/Index.cshtml
@@ -76,12 +76,19 @@
         document.querySelectorAll('.last-polled').forEach(function (cell) {
             var tid = cell.getAttribute('data-tenant');
             var val = localStorage.getItem('pollLast_' + tid);
-            if (val) {
-                try {
-                    var d = new Date(val);
-                    cell.textContent = d.toLocaleString();
-                } catch (e) {}
+
+            if (!val) {
+                cell.textContent = 'Not updated yet';
+                return;
             }
+
+            var d = new Date(val);
+            if (isNaN(d.getTime())) {
+                cell.textContent = 'Not updated yet';
+                return;
+            }
+
+            cell.textContent = d.toLocaleString();
         });
     </script>
 }

--- a/src/LastUpdate.jsx
+++ b/src/LastUpdate.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function LastUpdate({ timestamp }) {
+  if (!timestamp) {
+    return <span>Not updated yet</span>;
+  }
+
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return <span>Not updated yet</span>;
+  }
+
+  return <span>{date.toLocaleString()}</span>;
+}

--- a/src/LastUpdate.jsx
+++ b/src/LastUpdate.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function LastUpdate({ timestamp }) {
   if (!timestamp) {
     return <span>Not updated yet</span>;

--- a/src/__tests__/LastUpdate.test.jsx
+++ b/src/__tests__/LastUpdate.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import LastUpdate from '../LastUpdate';
+
+describe('LastUpdate', () => {
+  test('renders human-readable time for ISO string', () => {
+    const ts = '2024-01-01T12:34:56Z';
+    render(<LastUpdate timestamp={ts} />);
+    expect(screen.getByText(new Date(ts).toLocaleString())).toBeInTheDocument();
+  });
+
+  test('renders human-readable time for Date object', () => {
+    const date = new Date('2024-01-02T00:00:00Z');
+    render(<LastUpdate timestamp={date} />);
+    expect(screen.getByText(date.toLocaleString())).toBeInTheDocument();
+  });
+
+  test('renders fallback for undefined', () => {
+    render(<LastUpdate timestamp={undefined} />);
+    expect(screen.getByText('Not updated yet')).toBeInTheDocument();
+  });
+
+  test('does not show "Invalid time" for bad input', () => {
+    render(<LastUpdate timestamp="bad-value" />);
+    expect(screen.getByText('Not updated yet')).toBeInTheDocument();
+    expect(screen.queryByText(/Invalid/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- improve localStorage parsing for last poll time on home page
- add React component `LastUpdate` for consistent formatting
- cover `LastUpdate` scenarios with new tests

## Testing
- `npm install --no-audit --no-fund` *(failed: Exit handler never called)*
- `npx jest` *(failed: command hung due to missing modules)*
