### PR TITLE
Fix last updated timestamp

### DIFF
--- a/XeroNetStandardApp/Controllers/IdentityInfoController.cs
+++ b/XeroNetStandardApp/Controllers/IdentityInfoController.cs
@@ -127,8 +127,7 @@ namespace XeroNetStandardApp.Controllers
             }
 
             foreach (var kv in inserted)
-                if (kv.Value > 0)
-                    TempData[$"PollLast_{kv.Key}"] = DateTime.UtcNow.ToString("o");
+                TempData[$"PollLast_{kv.Key}"] = DateTime.UtcNow.ToString("o");
 
             TempData["Message"] =
                 tenantId == "ALL"

--- a/XeroNetStandardApp/Controllers/RawSyncController.cs
+++ b/XeroNetStandardApp/Controllers/RawSyncController.cs
@@ -44,8 +44,7 @@ namespace XeroNetStandardApp.Controllers
             foreach (var ep in selectedEndpoints)
                 totalRows += await _pollingService.RunEndpointAsync(tenantId, ep);
 
-            if (totalRows > 0)
-                TempData[$"PollLast_{tenantId}"] = DateTime.UtcNow.ToString("o");
+            TempData[$"PollLast_{tenantId}"] = DateTime.UtcNow.ToString("o");
 
             TempData["Message"] = "Polling triggered.";
             return RedirectToAction("Index", "IdentityInfo");


### PR DESCRIPTION
## Summary
- update polling controllers so last updated timestamp is recorded even when no rows are inserted

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test --silent` *(fails: `jest` not found)*