### PR TITLE
Show inserted row count

### DIFF
--- a/XeroNetStandardApp/Controllers/IdentityInfoController.cs
+++ b/XeroNetStandardApp/Controllers/IdentityInfoController.cs
@@ -127,7 +127,10 @@ namespace XeroNetStandardApp.Controllers
             }
 
             foreach (var kv in inserted)
+            {
                 TempData[$"PollLast_{kv.Key}"] = DateTime.UtcNow.ToString("o");
+                TempData[$"PollRows_{kv.Key}"] = kv.Value.ToString();
+            }
 
             TempData["Message"] =
                 tenantId == "ALL"

--- a/XeroNetStandardApp/Controllers/RawSyncController.cs
+++ b/XeroNetStandardApp/Controllers/RawSyncController.cs
@@ -45,6 +45,7 @@ namespace XeroNetStandardApp.Controllers
                 totalRows += await _pollingService.RunEndpointAsync(tenantId, ep);
 
             TempData[$"PollLast_{tenantId}"] = DateTime.UtcNow.ToString("o");
+            TempData[$"PollRows_{tenantId}"] = totalRows.ToString();
 
             TempData["Message"] = "Polling triggered.";
             return RedirectToAction("Index", "IdentityInfo");

--- a/XeroNetStandardApp/Views/Home/Index.cshtml
+++ b/XeroNetStandardApp/Views/Home/Index.cshtml
@@ -41,6 +41,7 @@
                         <th>Organisation</th>
                         <th>Tenant Id</th>
                         <th>Last Updated</th>
+                        <th>Rows Inserted</th>
                         <th></th>
                         <th></th>
                     </tr>
@@ -52,6 +53,7 @@
                             <td>@tenant.OrgName</td>
                             <td>@tenant.TenantId</td>
                             <td class="last-polled" data-tenant="@tenant.TenantId">—</td>
+                            <td class="last-rows" data-tenant="@tenant.TenantId">—</td>
                             <td>
                                 <a class="btn btn-primary btn-sm"
                                    asp-controller="Authorization"
@@ -89,6 +91,24 @@
             }
 
             cell.textContent = d.toLocaleString();
+        });
+
+        document.querySelectorAll('.last-rows').forEach(function (cell) {
+            var tid = cell.getAttribute('data-tenant');
+            var val = localStorage.getItem('pollRows_' + tid);
+
+            if (!val) {
+                cell.textContent = '—';
+                return;
+            }
+
+            var n = parseInt(val);
+            if (isNaN(n)) {
+                cell.textContent = '—';
+                return;
+            }
+
+            cell.textContent = n;
         });
     </script>
 }

--- a/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
+++ b/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
@@ -101,4 +101,15 @@
             }
         </script>
     }
+    @if (TempData.Keys.Any(k => k.StartsWith("PollRows_")))
+    {
+        <script>
+            @foreach (var key in TempData.Keys.Where(k => k.StartsWith("PollRows_")))
+            {
+                var tid = key.Substring("PollRows_".Length);
+                var val = TempData[key];
+                <text>localStorage.setItem('pollRows_@tid', '@val');</text>
+            }
+        </script>
+    }
 }


### PR DESCRIPTION
## Summary
- track how many rows are inserted when polling
- persist the last inserted count in the browser
- display that value on the Home index

## Testing
- `npm test --silent` *(fails: `jest: not found`)*
- `dotnet test` *(fails: `dotnet: command not found`)*