### PR TITLE
Add DB logging for each endpoint poll

### DIFF
--- a/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using XeroNetStandardApp.Services;
@@ -8,7 +9,7 @@ namespace XeroNetStandardApp.Tests.Helpers
     {
         public List<(string Tenant, string Endpoint)> Calls { get; } = new();
 
-        public Task<int> RunEndpointAsync(string tenantId, string endpointKey)
+        public Task<int> RunEndpointAsync(string tenantId, string endpointKey, DateTimeOffset callTime)
         {
             Calls.Add((tenantId, endpointKey));
             return Task.FromResult(0);

--- a/XeroNetStandardApp.Tests/PollingServiceTests.cs
+++ b/XeroNetStandardApp.Tests/PollingServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xero.NetStandard.OAuth2.Token;

--- a/XeroNetStandardApp.Tests/PollingServiceTests.cs
+++ b/XeroNetStandardApp.Tests/PollingServiceTests.cs
@@ -36,8 +36,12 @@ namespace XeroNetStandardApp.Tests
                 ExpiresAtUtc = DateTime.UtcNow.AddHours(1)
             });
 
-            var svc = new PollingService(tokenService, raw, NullLogger<PollingService>.Instance);
-            var rows = await svc.RunEndpointAsync("123", "assets");
+            var cfg = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+                .AddInMemoryCollection(new[] { new System.Collections.Generic.KeyValuePair<string,string>("ConnectionStrings:Postgres", "Host=localhost") })
+                .Build();
+
+            var svc = new PollingService(tokenService, raw, NullLogger<PollingService>.Instance, cfg);
+            var rows = await svc.RunEndpointAsync("123", "assets", DateTimeOffset.UtcNow);
 
             Assert.Equal(("123", "assets"), raw.LastCall);
             Assert.Equal(0, rows);

--- a/XeroNetStandardApp/Controllers/IdentityInfoController.cs
+++ b/XeroNetStandardApp/Controllers/IdentityInfoController.cs
@@ -102,6 +102,7 @@ namespace XeroNetStandardApp.Controllers
 
             // Run requested polling and capture number of rows inserted
             var inserted = new Dictionary<string, int>();
+            var callTime = DateTimeOffset.UtcNow;
 
             if (tenantId == "ALL")
             {
@@ -109,7 +110,7 @@ namespace XeroNetStandardApp.Controllers
                 {
                     var count = 0;
                     foreach (var ep in endpoints)
-                        count += await _pollingService.RunEndpointAsync(tId, ep);
+                        count += await _pollingService.RunEndpointAsync(tId, ep, callTime);
                     inserted[tId] = count;
                 }
             }
@@ -117,7 +118,7 @@ namespace XeroNetStandardApp.Controllers
             {
                 var count = 0;
                 foreach (var ep in endpointsForTenant)
-                    count += await _pollingService.RunEndpointAsync(tenantId, ep);
+                    count += await _pollingService.RunEndpointAsync(tenantId, ep, callTime);
                 inserted[tenantId] = count;
             }
             else

--- a/XeroNetStandardApp/Controllers/RawSyncController.cs
+++ b/XeroNetStandardApp/Controllers/RawSyncController.cs
@@ -41,8 +41,9 @@ namespace XeroNetStandardApp.Controllers
             }
 
             var totalRows = 0;
+            var callTime = DateTimeOffset.UtcNow;
             foreach (var ep in selectedEndpoints)
-                totalRows += await _pollingService.RunEndpointAsync(tenantId, ep);
+                totalRows += await _pollingService.RunEndpointAsync(tenantId, ep, callTime);
 
             Console.WriteLine($"Run time: {DateTime.UtcNow.ToString("o")}");
             Console.WriteLine($"Total rows: {totalRows}");

--- a/XeroNetStandardApp/Services/IPollingService.cs
+++ b/XeroNetStandardApp/Services/IPollingService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace XeroNetStandardApp.Services
 {
@@ -8,6 +9,6 @@ namespace XeroNetStandardApp.Services
         /// Runs the ingest pipeline for a specific endpoint and returns the
         /// number of rows inserted.
         /// </summary>
-        Task<int> RunEndpointAsync(string tenantId, string endpointKey);
+        Task<int> RunEndpointAsync(string tenantId, string endpointKey, DateTimeOffset callTime);
     }
 }

--- a/XeroNetStandardApp/Services/PollingService.cs
+++ b/XeroNetStandardApp/Services/PollingService.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using Xero.NetStandard.OAuth2.Token;
 
 namespace XeroNetStandardApp.Services
@@ -10,27 +13,75 @@ namespace XeroNetStandardApp.Services
         private readonly TokenService _tokenService;
         private readonly IXeroRawIngestService _ingestSvc;
         private readonly ILogger<PollingService> _log;
+        private readonly string _connString;
 
         public PollingService(
             TokenService tokenService,
             IXeroRawIngestService ingestSvc,
-            ILogger<PollingService> log)
+            ILogger<PollingService> log,
+            IConfiguration cfg)
         {
             _tokenService = tokenService;
             _ingestSvc = ingestSvc;
             _log = log;
+            _connString = cfg.GetConnectionString("Postgres")
+                         ?? throw new InvalidOperationException("Postgres conn string missing");
         }
 
-        public async Task<int> RunEndpointAsync(string tenantId, string endpointKey)
+        public async Task<int> RunEndpointAsync(string tenantId, string endpointKey, DateTimeOffset callTime)
         {
             XeroOAuth2Token? tok = _tokenService.RetrieveToken();
             if (tok == null || string.IsNullOrEmpty(tok.AccessToken))
                 throw new InvalidOperationException("No valid Xero token on file.");
 
-            var rows = await _ingestSvc.RunOnceAsync(tenantId, endpointKey);
+            int rows = 0;
+            int? statusCode = null;
+            bool success;
+            string? errorMessage = null;
+
+            try
+            {
+                rows = await _ingestSvc.RunOnceAsync(tenantId, endpointKey);
+                statusCode = 200;
+                success = true;
+            }
+            catch (Exception ex)
+            {
+                success = false;
+                statusCode = 500;
+                errorMessage = ex.Message;
+                _log.LogError(ex, "Polling failed for {Endpoint} and tenant {Tenant}", endpointKey, tenantId);
+            }
+
+            await LogResultAsync(tenantId, endpointKey, rows, callTime, statusCode, success, errorMessage);
 
             _log.LogInformation("Polled {Endpoint} for tenant {Tenant}", endpointKey, tenantId);
             return rows;
+        }
+
+        private async Task LogResultAsync(string tenantId, string endpointKey, int rows, DateTimeOffset callTime, int? statusCode, bool success, string? errorMessage)
+        {
+            try
+            {
+                await using var conn = new NpgsqlConnection(_connString);
+                const string sql = @"INSERT INTO utils.api_call_log (organisation_id, endpoint, rows_inserted, call_time, status_code, success, error_message)
+                                      VALUES (@OrgId, @Endpoint, @Rows, @CallTime, @StatusCode, @Success, @Error);";
+
+                await conn.ExecuteAsync(sql, new
+                {
+                    OrgId = Guid.Parse(tenantId),
+                    Endpoint = endpointKey,
+                    Rows = rows,
+                    CallTime = callTime,
+                    StatusCode = statusCode,
+                    Success = success,
+                    Error = errorMessage
+                });
+            }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "Failed to record api_call_log for {Endpoint}", endpointKey);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- record polling results in `utils.api_call_log`
- provide timestamp to `RunEndpointAsync` so all logs share initiation time
- pass timestamp from controllers
- update tests and stubs for new service API

## Testing
- `npm test` *(fails: jest not found)*
- `dotnet test` *(fails: dotnet not found)*