### PR TITLE
Add progress overlay and display API call summary

### DIFF
--- a/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using XeroNetStandardApp.Services;
+using XeroNetStandardApp.Models;
 
 namespace XeroNetStandardApp.Tests.Helpers
 {
@@ -14,5 +15,8 @@ namespace XeroNetStandardApp.Tests.Helpers
             Calls.Add((tenantId, endpointKey));
             return Task.FromResult(0);
         }
+
+        public Task<IReadOnlyList<PollingStats>> GetPollingStatsAsync()
+            => Task.FromResult<IReadOnlyList<PollingStats>>(new List<PollingStats>());
     }
 }

--- a/XeroNetStandardApp/Controllers/IdentityInfoController.cs
+++ b/XeroNetStandardApp/Controllers/IdentityInfoController.cs
@@ -85,6 +85,9 @@ namespace XeroNetStandardApp.Controllers
                 }
             };
 
+            var stats = await _pollingService.GetPollingStatsAsync();
+            model.Stats = stats.ToDictionary(s => s.OrganisationId.ToString());
+
             return View(model);
         }
 

--- a/XeroNetStandardApp/Models/EndpointControlPanelViewModel.cs
+++ b/XeroNetStandardApp/Models/EndpointControlPanelViewModel.cs
@@ -6,6 +6,7 @@ namespace XeroNetStandardApp.Models
     {
         public List<OrgTenant> Tenants { get; set; } = new();
         public List<EndpointOption> Endpoints { get; set; } = new();
+        public Dictionary<string, PollingStats> Stats { get; set; } = new();
     }
 
     public class OrgTenant

--- a/XeroNetStandardApp/Models/PollingStats.cs
+++ b/XeroNetStandardApp/Models/PollingStats.cs
@@ -1,0 +1,11 @@
+namespace XeroNetStandardApp.Models
+{
+    public class PollingStats
+    {
+        public System.Guid OrganisationId { get; set; }
+        public System.DateTimeOffset LastCall { get; set; }
+        public int EndpointsSuccess { get; set; }
+        public int EndpointsFail { get; set; }
+        public int RecordsInserted { get; set; }
+    }
+}

--- a/XeroNetStandardApp/Services/IPollingService.cs
+++ b/XeroNetStandardApp/Services/IPollingService.cs
@@ -10,5 +10,11 @@ namespace XeroNetStandardApp.Services
         /// number of rows inserted.
         /// </summary>
         Task<int> RunEndpointAsync(string tenantId, string endpointKey, DateTimeOffset callTime);
+
+        /// <summary>
+        /// Return aggregated statistics for each organisation based on the
+        /// <c>utils.api_call_log</c> table.
+        /// </summary>
+        Task<IReadOnlyList<PollingStats>> GetPollingStatsAsync();
     }
 }

--- a/XeroNetStandardApp/Services/PollingService.cs
+++ b/XeroNetStandardApp/Services/PollingService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using Xero.NetStandard.OAuth2.Token;
+using XeroNetStandardApp.Models;
 
 namespace XeroNetStandardApp.Services
 {
@@ -57,6 +58,22 @@ namespace XeroNetStandardApp.Services
 
             _log.LogInformation("Polled {Endpoint} for tenant {Tenant}", endpointKey, tenantId);
             return rows;
+        }
+
+        public async Task<IReadOnlyList<PollingStats>> GetPollingStatsAsync()
+        {
+            const string sql = @"SELECT 
+    organisation_id AS OrganisationId,
+    max(call_time) AS LastCall,
+    SUM(CASE WHEN status_code = 200 THEN 1 ELSE 0 END) AS EndpointsSuccess,
+    SUM(CASE WHEN status_code <> 200 THEN 1 ELSE 0 END) AS EndpointsFail,
+    SUM(rows_inserted) AS RecordsInserted
+FROM utils.api_call_log
+GROUP BY organisation_id;";
+
+            await using var conn = new NpgsqlConnection(_connString);
+            var result = await conn.QueryAsync<PollingStats>(sql);
+            return result.AsList();
         }
 
         private async Task LogResultAsync(string tenantId, string endpointKey, int rows, DateTimeOffset callTime, int? statusCode, bool success, string? errorMessage)

--- a/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
+++ b/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
@@ -78,6 +78,41 @@
 
 </form>
 
+<div id="runProgress" class="position-fixed top-0 start-0 w-100 h-100 d-none align-items-center justify-content-center" style="background:rgba(255,255,255,0.8);z-index:1050;">
+    <div class="text-center">
+        <div class="spinner-border" role="status"></div>
+        <div class="mt-2">Processing...</div>
+    </div>
+</div>
+
+<h3>Last Run Summary</h3>
+<table class="table table-sm">
+    <thead>
+        <tr>
+            <th>Organisation</th>
+            <th>Last Call (UTC)</th>
+            <th>Successes</th>
+            <th>Failures</th>
+            <th>Rows Inserted</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var t in Model.Tenants)
+        {
+            if (Model.Stats.TryGetValue(t.TenantId!, out var s))
+            {
+                <tr>
+                    <td>@t.OrgName</td>
+                    <td>@s.LastCall.ToString("g")</td>
+                    <td>@s.EndpointsSuccess</td>
+                    <td>@s.EndpointsFail</td>
+                    <td>@s.RecordsInserted</td>
+                </tr>
+            }
+        }
+    </tbody>
+</table>
+
 @section Scripts {
     <script>
         // toggle an entire tenant column
@@ -88,6 +123,9 @@
                 document.querySelectorAll('.tenant-' + tid)
                         .forEach(cb => cb.checked = toggle.checked);
             });
+        });
+        document.querySelector('form')?.addEventListener('submit', function () {
+            document.getElementById('runProgress')?.classList.remove('d-none');
         });
     </script>
     @if (TempData.Keys.Any(k => k.StartsWith("PollLast_")))


### PR DESCRIPTION
## Summary
- show spinner overlay and results table on IdentityInfo page
- provide polling stats via IPollingService
- load stats in controller and display in view
- add PollingStats model
- update tests' stub service

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test --silent` *(fails: `jest` not found)*