### PR TITLE
Improve manual run summary

### DIFF
--- a/XeroNetStandardApp.Tests/Helpers/FakeTokenService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/FakeTokenService.cs
@@ -1,0 +1,23 @@
+using XeroNetStandardApp.Services;
+using Xero.NetStandard.OAuth2.Token;
+using System;
+
+namespace XeroNetStandardApp.Tests.Helpers
+{
+    public class FakeTokenService : TokenService
+    {
+        public FakeTokenService() : base(null, null) { }
+
+        public override XeroOAuth2Token RetrieveToken()
+        {
+            // Return a dummy token with the shape your app expects
+            return new XeroOAuth2Token
+            {
+                AccessToken = "fake-access-token",
+                ExpiresAtUtc = DateTime.UtcNow.AddHours(1),
+                RefreshToken = "fake-refresh-token"
+                // Add any other required fields if your code expects them
+            };
+        }
+    }
+}

--- a/XeroNetStandardApp.Tests/Helpers/FakeTokenService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/FakeTokenService.cs
@@ -1,12 +1,13 @@
 using XeroNetStandardApp.Services;
 using Xero.NetStandard.OAuth2.Token;
+using Microsoft.AspNetCore.DataProtection; // Ensure this is added
 using System;
 
 namespace XeroNetStandardApp.Tests.Helpers
 {
     public class FakeTokenService : TokenService
     {
-        public FakeTokenService() : base(null, null) { }
+        public FakeTokenService(IDataProtectionProvider provider) : base(provider) { }
 
         public override XeroOAuth2Token RetrieveToken()
         {

--- a/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
+++ b/XeroNetStandardApp.Tests/Helpers/StubPollingService.cs
@@ -18,5 +18,8 @@ namespace XeroNetStandardApp.Tests.Helpers
 
         public Task<IReadOnlyList<PollingStats>> GetPollingStatsAsync()
             => Task.FromResult<IReadOnlyList<PollingStats>>(new List<PollingStats>());
+
+        public Task<IReadOnlyList<PollingStats>> GetPollingStatsForRunAsync(DateTimeOffset callTime)
+            => Task.FromResult<IReadOnlyList<PollingStats>>(new List<PollingStats>());
     }
 }

--- a/XeroNetStandardApp.Tests/Helpers/TestApiFactory.cs
+++ b/XeroNetStandardApp.Tests/Helpers/TestApiFactory.cs
@@ -14,12 +14,21 @@ namespace XeroNetStandardApp.Tests.Helpers
         {
             builder.ConfigureServices(services =>
             {
-                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IPollingService));
-                if (descriptor != null)
+                // Replace IPollingService with stub
+                var pollingDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IPollingService));
+                if (pollingDescriptor != null)
                 {
-                    services.Remove(descriptor);
+                    services.Remove(pollingDescriptor);
                 }
                 services.AddSingleton<IPollingService>(StubPolling);
+
+                // Replace TokenService with fake
+                var tokenDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(TokenService));
+                if (tokenDescriptor != null)
+                {
+                    services.Remove(tokenDescriptor);
+                }
+                services.AddSingleton<TokenService, FakeTokenService>();
             });
         }
     }

--- a/XeroNetStandardApp.Tests/IdentityInfoTests.cs
+++ b/XeroNetStandardApp.Tests/IdentityInfoTests.cs
@@ -33,7 +33,18 @@ namespace XeroNetStandardApp.Tests
             });
 
             var response = await _client.PostAsync("/IdentityInfo/BulkTrigger", content);
+            var response = await _client.PostAsync("/IdentityInfo/BulkTrigger", content);
 
+            if (response.StatusCode != HttpStatusCode.Redirect)
+            {
+                // Get the full response content
+                var body = await response.Content.ReadAsStringAsync();
+                // Throw with details, which will show up in CI logs
+                throw new Exception(
+                    $"Failed with status: {response.StatusCode}\nResponse body:\n{body}"
+                );
+            }
+            
             Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             Assert.Contains(_factory.StubPolling.Calls, c => c.Tenant == "123" && c.Endpoint == "accounts");
             Assert.Contains(_factory.StubPolling.Calls, c => c.Tenant == "123" && c.Endpoint == "invoices");

--- a/XeroNetStandardApp.Tests/IdentityInfoTests.cs
+++ b/XeroNetStandardApp.Tests/IdentityInfoTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -32,7 +33,6 @@ namespace XeroNetStandardApp.Tests
                 new KeyValuePair<string,string>("selected[123][]", "invoices")
             });
 
-            var response = await _client.PostAsync("/IdentityInfo/BulkTrigger", content);
             var response = await _client.PostAsync("/IdentityInfo/BulkTrigger", content);
 
             if (response.StatusCode != HttpStatusCode.Redirect)

--- a/XeroNetStandardApp/Services/IPollingService.cs
+++ b/XeroNetStandardApp/Services/IPollingService.cs
@@ -19,5 +19,12 @@ namespace XeroNetStandardApp.Services
         /// <c>utils.api_call_log</c> table.
         /// </summary>
         Task<IReadOnlyList<PollingStats>> GetPollingStatsAsync();
+
+        /// <summary>
+        /// Return aggregated statistics for the given run (identified by
+        /// <paramref name="callTime"/>). This is useful for summarising a
+        /// manual polling operation.
+        /// </summary>
+        Task<IReadOnlyList<PollingStats>> GetPollingStatsForRunAsync(DateTimeOffset callTime);
     }
 }

--- a/XeroNetStandardApp/Services/TokenService.cs
+++ b/XeroNetStandardApp/Services/TokenService.cs
@@ -24,7 +24,7 @@ namespace XeroNetStandardApp.Services
             File.WriteAllText(_tokenFilePath, encryptedToken);
         }
 
-        public XeroOAuth2Token? RetrieveToken()
+        public virtual XeroOAuth2Token? RetrieveToken()
         {
             if (!File.Exists(_tokenFilePath))
                 return null;

--- a/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
+++ b/XeroNetStandardApp/Views/IdentityInfo/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@model XeroNetStandardApp.Models.EndpointControlPanelViewModel
+@using System.Text.Json
 @{
     ViewBag.Title = "Endpoint Control Panel";
 }
@@ -81,7 +82,7 @@
 <div id="runProgress" class="position-fixed top-0 start-0 w-100 h-100 d-none align-items-center justify-content-center" style="background:rgba(255,255,255,0.8);z-index:1050;">
     <div class="text-center">
         <div class="spinner-border" role="status"></div>
-        <div class="mt-2">Processing...</div>
+        <div id="runProgressMessage" class="mt-2">Processing...</div>
     </div>
 </div>
 
@@ -125,7 +126,22 @@
             });
         });
         document.querySelector('form')?.addEventListener('submit', function () {
-            document.getElementById('runProgress')?.classList.remove('d-none');
+            const overlay = document.getElementById('runProgress');
+            const msg = document.getElementById('runProgressMessage');
+            if (msg) msg.textContent = 'Manual data load initiated';
+            overlay?.classList.remove('d-none');
+        });
+
+        window.addEventListener('DOMContentLoaded', function () {
+            var finalMsg = @Html.Raw(JsonSerializer.Serialize(TempData["RunStatus"]));
+            if (finalMsg) {
+                const overlay = document.getElementById('runProgress');
+                const msg = document.getElementById('runProgressMessage');
+                overlay.querySelector('.spinner-border')?.classList.add('d-none');
+                if (msg) msg.textContent = finalMsg;
+                overlay?.classList.remove('d-none');
+                setTimeout(() => overlay?.classList.add('d-none'), 5000);
+            }
         });
     </script>
     @if (TempData.Keys.Any(k => k.StartsWith("PollLast_")))


### PR DESCRIPTION
## Summary
- query run results using a new method in `PollingService`
- implement `GetPollingStatsForRunAsync` to summarise each manual run
- update controller to build overlay message from query results
- extend stub polling service for tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test --silent` *(fails: `jest` not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.