### PR TITLE
Add data load log viewer

### DIFF
--- a/XeroNetStandardApp/Controllers/DataLoadLogsController.cs
+++ b/XeroNetStandardApp/Controllers/DataLoadLogsController.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using XeroNetStandardApp.Services;
+using XeroNetStandardApp.Models;
+
+namespace XeroNetStandardApp.Controllers
+{
+    public class DataLoadLogsController : Controller
+    {
+        private readonly ICallLogService _logs;
+        private readonly ILogger<DataLoadLogsController> _logger;
+
+        public DataLoadLogsController(ICallLogService logs, ILogger<DataLoadLogsController> logger)
+        {
+            _logs = logs;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(string tenantId, string? orgName)
+        {
+            if (string.IsNullOrWhiteSpace(tenantId) || !Guid.TryParse(tenantId, out var orgGuid))
+            {
+                _logger.LogWarning("Invalid tenantId '{TenantId}' supplied to logs page", tenantId);
+                return BadRequest("Invalid organisation id.");
+            }
+
+            var logs = await _logs.GetLogsAsync(orgGuid);
+            var model = new ApiCallLogViewModel
+            {
+                TenantId = tenantId,
+                OrgName = orgName ?? tenantId,
+                Logs = logs.ToList()
+            };
+            return View(model);
+        }
+    }
+}

--- a/XeroNetStandardApp/Models/ApiCallLogEntry.cs
+++ b/XeroNetStandardApp/Models/ApiCallLogEntry.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XeroNetStandardApp.Models
+{
+    public class ApiCallLogEntry
+    {
+        public DateTimeOffset CallTime { get; set; }
+        public string? Endpoint { get; set; }
+        public int RowsInserted { get; set; }
+        public int? StatusCode { get; set; }
+        public bool Success { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/XeroNetStandardApp/Models/ApiCallLogViewModel.cs
+++ b/XeroNetStandardApp/Models/ApiCallLogViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace XeroNetStandardApp.Models
+{
+    public class ApiCallLogViewModel
+    {
+        public string? TenantId { get; set; }
+        public string? OrgName { get; set; }
+        public List<ApiCallLogEntry> Logs { get; set; } = new();
+    }
+}

--- a/XeroNetStandardApp/Program.cs
+++ b/XeroNetStandardApp/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddTransient<IXeroRawIngestService, XeroRawIngestService>();
 builder.Services.AddTransient<TokenService>();
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddScoped<IPollingService, PollingService>();
+builder.Services.AddScoped<ICallLogService, CallLogService>();
 builder.Services.AddSession();
 builder.Services.AddMvc(options => options.EnableEndpointRouting = false);
 builder.Services.AddDataProtection()

--- a/XeroNetStandardApp/Services/CallLogService.cs
+++ b/XeroNetStandardApp/Services/CallLogService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using XeroNetStandardApp.Models;
+
+namespace XeroNetStandardApp.Services
+{
+    public class CallLogService : ICallLogService
+    {
+        private readonly string _connString;
+
+        public CallLogService(IConfiguration configuration)
+        {
+            _connString = configuration.GetConnectionString("Postgres")
+                         ?? throw new InvalidOperationException("Postgres conn string missing");
+        }
+
+        public async Task<IReadOnlyList<ApiCallLogEntry>> GetLogsAsync(Guid organisationId)
+        {
+            const string sql = @"SELECT call_time, endpoint, rows_inserted, status_code, success, error_message
+                                  FROM utils.api_call_log
+                                 WHERE organisation_id = @OrgId
+                                 ORDER BY call_time desc, endpoint asc;";
+            await using var conn = new NpgsqlConnection(_connString);
+            var result = await conn.QueryAsync<ApiCallLogEntry>(sql, new { OrgId = organisationId });
+            return result.AsList();
+        }
+    }
+}

--- a/XeroNetStandardApp/Services/ICallLogService.cs
+++ b/XeroNetStandardApp/Services/ICallLogService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using XeroNetStandardApp.Models;
+
+namespace XeroNetStandardApp.Services
+{
+    public interface ICallLogService
+    {
+        Task<IReadOnlyList<ApiCallLogEntry>> GetLogsAsync(Guid organisationId);
+    }
+}

--- a/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
+++ b/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
@@ -1,0 +1,34 @@
+@model XeroNetStandardApp.Models.ApiCallLogViewModel
+@{
+    ViewData["Title"] = "Data Load Logs";
+}
+<h2>Data Load Logs for @Model.OrgName</h2>
+<table class="table table-sm">
+    <thead>
+        <tr>
+            <th style="width:2rem;"></th>
+            <th>Date/Time (UTC)</th>
+        </tr>
+    </thead>
+    <tbody>
+    @for (var i = 0; i < Model.Logs.Count; i++)
+    {
+        var log = Model.Logs[i];
+        <tr data-bs-toggle="collapse" data-bs-target="#detail-@i" style="cursor:pointer;">
+            <td class="text-center">+</td>
+            <td>@log.CallTime.ToString("g")</td>
+        </tr>
+        <tr id="detail-@i" class="collapse">
+            <td colspan="2">
+                <div>
+                    <strong>Endpoint:</strong> @log.Endpoint <br />
+                    <strong>Rows Inserted:</strong> @log.RowsInserted <br />
+                    <strong>Status Code:</strong> @log.StatusCode <br />
+                    <strong>Success:</strong> @log.Success <br />
+                    <strong>Error:</strong> @log.ErrorMessage
+                </div>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/XeroNetStandardApp/Views/Home/Index.cshtml
+++ b/XeroNetStandardApp/Views/Home/Index.cshtml
@@ -43,6 +43,7 @@
                         <th>Rows Inserted</th>
                         <th></th>
                         <th></th>
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -53,6 +54,13 @@
                             <td>@tenant.TenantId</td>
                             <td class="last-polled" data-tenant="@tenant.TenantId">—</td>
                             <td class="last-rows" data-tenant="@tenant.TenantId">—</td>
+                            <td>
+                                <a class="btn btn-secondary btn-sm"
+                                   asp-controller="DataLoadLogs"
+                                   asp-action="Index"
+                                   asp-route-tenantId="@tenant.TenantId"
+                                   asp-route-orgName="@tenant.OrgName">Data Load Logs</a>
+                            </td>
                             <td>
                                 <a class="btn btn-primary btn-sm"
                                    asp-controller="Authorization"


### PR DESCRIPTION
## Summary
- add service and model for reading api call logs
- display logs via new `DataLoadLogs` controller & page
- link to logs from Home page
- register `ICallLogService` in Program

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test` *(fails: `jest: not found`)*