### PR TITLE
Fix data load logs view and db connection

### DIFF
--- a/XeroNetStandardApp/Services/CallLogService.cs
+++ b/XeroNetStandardApp/Services/CallLogService.cs
@@ -15,6 +15,7 @@ namespace XeroNetStandardApp.Services
         public CallLogService(IConfiguration configuration)
         {
             _connString = configuration.GetConnectionString("Postgres")
+                         ?? Environment.GetEnvironmentVariable("POSTGRES_CONN_STRING")
                          ?? throw new InvalidOperationException("Postgres conn string missing");
         }
 

--- a/XeroNetStandardApp/Services/PollingService.cs
+++ b/XeroNetStandardApp/Services/PollingService.cs
@@ -27,6 +27,7 @@ namespace XeroNetStandardApp.Services
             _ingestSvc = ingestSvc;
             _log = log;
             _connString = cfg.GetConnectionString("Postgres")
+                         ?? Environment.GetEnvironmentVariable("POSTGRES_CONN_STRING")
                          ?? throw new InvalidOperationException("Postgres conn string missing");
         }
 

--- a/XeroNetStandardApp/Services/XeroRawIngestService.cs
+++ b/XeroNetStandardApp/Services/XeroRawIngestService.cs
@@ -54,6 +54,7 @@ namespace XeroNetStandardApp.Services
             _log = log;
             _tokenService = tokenService;
             _connString = cfg.GetConnectionString("Postgres")
+                           ?? Environment.GetEnvironmentVariable("POSTGRES_CONN_STRING")
                            ?? throw new InvalidOperationException("Postgres conn string missing");
         }
 

--- a/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
+++ b/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
@@ -14,13 +14,17 @@
     @for (var i = 0; i < Model.Logs.Count; i++)
     {
         var log = Model.Logs[i];
-        <tr data-bs-toggle="collapse" data-bs-target="#detail-@i" style="cursor:pointer;">
-            <td class="text-center">+</td>
-            <td>@log.CallTime.ToString("g")</td>
+        <tr>
+            <td class="text-center">
+                <button class="btn btn-link p-0" type="button"
+                        data-bs-toggle="collapse" data-bs-target="#detail-@i"
+                        aria-expanded="false" aria-controls="detail-@i">+</button>
+            </td>
+            <td>@log.CallTime.ToUniversalTime().ToString("u")</td>
         </tr>
-        <tr id="detail-@i" class="collapse">
-            <td colspan="2">
-                <div>
+        <tr>
+            <td colspan="2" class="p-0">
+                <div id="detail-@i" class="collapse ps-3">
                     <strong>Endpoint:</strong> @log.Endpoint <br />
                     <strong>Rows Inserted:</strong> @log.RowsInserted <br />
                     <strong>Status Code:</strong> @log.StatusCode <br />


### PR DESCRIPTION
## Summary
- make the data load logs table collapsible with a button
- allow services to load DB connection string from `POSTGRES_CONN_STRING` env var

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `dotnet test` *(fails: command not found)*