### PR TITLE
Fix data load log toggle and null call time

### DIFF
--- a/XeroNetStandardApp/Models/ApiCallLogEntry.cs
+++ b/XeroNetStandardApp/Models/ApiCallLogEntry.cs
@@ -4,7 +4,7 @@ namespace XeroNetStandardApp.Models
 {
     public class ApiCallLogEntry
     {
-        public DateTimeOffset CallTime { get; set; }
+        public DateTimeOffset? CallTime { get; set; }
         public string? Endpoint { get; set; }
         public int RowsInserted { get; set; }
         public int? StatusCode { get; set; }

--- a/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
+++ b/XeroNetStandardApp/Views/DataLoadLogs/Index.cshtml
@@ -20,7 +20,7 @@
                         data-bs-toggle="collapse" data-bs-target="#detail-@i"
                         aria-expanded="false" aria-controls="detail-@i">+</button>
             </td>
-            <td>@log.CallTime.ToUniversalTime().ToString("u")</td>
+            <td>@(log.CallTime?.UtcDateTime.ToString("u") ?? "")</td>
         </tr>
         <tr>
             <td colspan="2" class="p-0">
@@ -36,3 +36,7 @@
     }
     </tbody>
 </table>
+
+@section Scripts {
+    <script src="~/js/data-load-logs.js"></script>
+}

--- a/XeroNetStandardApp/wwwroot/js/data-load-logs.js
+++ b/XeroNetStandardApp/wwwroot/js/data-load-logs.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-undef */
+/**
+ * data-load-logs.js
+ * Handles “+ / –” toggle and row collapse on the Data-load logs page.
+ *
+ * Depends on: bootstrap.bundle.min.js (for Collapse), no jQuery needed.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // Event delegation so it works for every button in the table
+  document.querySelector('table.table').addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-bs-toggle="collapse"]');
+    if (!btn) return;                // not a toggle button
+
+    const targetSel = btn.getAttribute('data-bs-target');
+    const target    = document.querySelector(targetSel);
+    if (!target) return;
+
+    // When the collapse finishes opening, swap to "–"
+    target.addEventListener('shown.bs.collapse', () => { btn.textContent = '–'; }, { once: true });
+    // When the collapse finishes closing, swap back to "+"
+    target.addEventListener('hidden.bs.collapse', () => { btn.textContent = '+'; }, { once: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add JS for expanding/collapsing log rows
- load the new script from the logs view
- allow `CallTime` to be nullable and handle null values in the view

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `dotnet test` *(fails: dotnet not found)*