### PR TITLE
Persist polling configuration to backend

### DIFF
--- a/XeroNetStandardApp/Models/PollingConfigViewModel.cs
+++ b/XeroNetStandardApp/Models/PollingConfigViewModel.cs
@@ -11,4 +11,9 @@ public class PollingConfigViewModel
     /// scheduled for polling.
     /// </summary>
     public List<EndpointOption> Endpoints { get; set; } = new();
+
+    /// <summary>
+    /// Existing polling settings keyed by organisation id.
+    /// </summary>
+    public Dictionary<string, PollingSetting> Settings { get; set; } = new();
 }

--- a/XeroNetStandardApp/Models/PollingSetting.cs
+++ b/XeroNetStandardApp/Models/PollingSetting.cs
@@ -1,0 +1,9 @@
+namespace XeroNetStandardApp.Models;
+
+public class PollingSetting
+{
+    public System.Guid OrganisationId { get; set; }
+    public string PollingSchedule { get; set; } = string.Empty;
+    public System.TimeSpan? RunTime { get; set; }
+    public string[] EnabledEndpoints { get; set; } = System.Array.Empty<string>();
+}

--- a/XeroNetStandardApp/Program.cs
+++ b/XeroNetStandardApp/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddTransient<TokenService>();
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddScoped<IPollingService, PollingService>();
 builder.Services.AddScoped<ICallLogService, CallLogService>();
+builder.Services.AddScoped<IPollingSettingsService, PollingSettingsService>();
 builder.Services.AddSession();
 builder.Services.AddMvc(options => options.EnableEndpointRouting = false);
 builder.Services.AddDataProtection()

--- a/XeroNetStandardApp/Services/IPollingSettingsService.cs
+++ b/XeroNetStandardApp/Services/IPollingSettingsService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using XeroNetStandardApp.Models;
+
+namespace XeroNetStandardApp.Services
+{
+    public interface IPollingSettingsService
+    {
+        Task<PollingSetting?> GetAsync(Guid organisationId);
+        Task<IReadOnlyDictionary<Guid, PollingSetting>> GetManyAsync(IEnumerable<Guid> organisationIds);
+        Task UpsertAsync(Guid organisationId, string schedule, TimeSpan? runTime, IEnumerable<string> endpoints);
+    }
+}

--- a/XeroNetStandardApp/Services/PollingSettingsService.cs
+++ b/XeroNetStandardApp/Services/PollingSettingsService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using XeroNetStandardApp.Models;
+
+namespace XeroNetStandardApp.Services
+{
+    public class PollingSettingsService : IPollingSettingsService
+    {
+        private readonly string _connString;
+
+        public PollingSettingsService(IConfiguration cfg)
+        {
+            _connString = cfg.GetConnectionString("Postgres")
+                         ?? Environment.GetEnvironmentVariable("POSTGRES_CONN_STRING")
+                         ?? throw new InvalidOperationException("Postgres conn string missing");
+        }
+
+        public async Task<PollingSetting?> GetAsync(Guid organisationId)
+        {
+            const string sql = @"SELECT organisation_id AS OrganisationId,
+                                         polling_schedule AS PollingSchedule,
+                                         run_time AS RunTime,
+                                         enabled_endpoints AS EnabledEndpoints
+                                    FROM backendutils.polling_settings
+                                   WHERE organisation_id = @OrgId;";
+            await using var conn = new NpgsqlConnection(_connString);
+            return await conn.QueryFirstOrDefaultAsync<PollingSetting>(sql, new { OrgId = organisationId });
+        }
+
+        public async Task<IReadOnlyDictionary<Guid, PollingSetting>> GetManyAsync(IEnumerable<Guid> organisationIds)
+        {
+            var ids = organisationIds.ToArray();
+            if (ids.Length == 0) return new Dictionary<Guid, PollingSetting>();
+
+            const string sql = @"SELECT organisation_id AS OrganisationId,
+                                         polling_schedule AS PollingSchedule,
+                                         run_time AS RunTime,
+                                         enabled_endpoints AS EnabledEndpoints
+                                    FROM backendutils.polling_settings
+                                   WHERE organisation_id = ANY(@OrgIds);";
+            await using var conn = new NpgsqlConnection(_connString);
+            var list = await conn.QueryAsync<PollingSetting>(sql, new { OrgIds = ids });
+            return list.ToDictionary(p => p.OrganisationId);
+        }
+
+        public async Task UpsertAsync(Guid organisationId, string schedule, TimeSpan? runTime, IEnumerable<string> endpoints)
+        {
+            const string sql = @"INSERT INTO backendutils.polling_settings
+                                 (organisation_id, polling_schedule, run_time, enabled_endpoints)
+                                 VALUES (@OrgId, @Sched, @RunTime, @Endpoints)
+                                 ON CONFLICT (organisation_id)
+                                 DO UPDATE SET polling_schedule = EXCLUDED.polling_schedule,
+                                               run_time = EXCLUDED.run_time,
+                                               enabled_endpoints = EXCLUDED.enabled_endpoints;";
+            await using var conn = new NpgsqlConnection(_connString);
+            await conn.ExecuteAsync(sql, new
+            {
+                OrgId = organisationId,
+                Sched = schedule,
+                RunTime = runTime,
+                Endpoints = endpoints.ToArray()
+            });
+        }
+    }
+}
+

--- a/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
+++ b/XeroNetStandardApp/Views/PollingConfig/Index.cshtml
@@ -5,6 +5,16 @@
     var tenantJson = System.Text.Json.JsonSerializer.Serialize(
         Model.Tenants.Select(t => new { t.TenantId, t.OrgName })
     );
+    var scheduleJson = System.Text.Json.JsonSerializer.Serialize(
+        Model.Settings.ToDictionary(
+            kv => kv.Key,
+            kv => new
+            {
+                kv.Value.PollingSchedule,
+                RunTime = kv.Value.RunTime?.ToString(@"hh\:mm"),
+                kv.Value.EnabledEndpoints
+            })
+    );
 }
 
 <h2>Polling Configuration</h2>
@@ -108,6 +118,9 @@
 <script id="tenant-data" type="application/json">
     @Html.Raw(tenantJson)
 </script>
+<script id="schedule-data" type="application/json">
+    @Html.Raw(scheduleJson)
+</script>
 
 @section Scripts {
     <script type="text/javascript">
@@ -128,55 +141,30 @@
             const tenants = JSON.parse(
                 document.getElementById('tenant-data').textContent
             );
+            const schedules = JSON.parse(
+                document.getElementById('schedule-data').textContent || '{}'
+            );
 
             tenants.forEach(t => {
-                const raw = localStorage.getItem(`pollConf_${t.TenantId}`);
-                if (!raw) return;
+                const cfg = schedules[t.TenantId];
+                if (!cfg) return;
 
-                try {
-                    const cfg = JSON.parse(raw);
-
-                    (cfg.selected || []).forEach(k => {
-                        const box = document.querySelector(
-                            `.ep-checkbox[data-tenant="${t.TenantId}"][value="${k}"]`
-                        );
-                        if (box) box.checked = true;
-                    });
-
-                    const freqSel = document.querySelector(
-                        `.freq-select[data-tenant="${t.TenantId}"]`
+                (cfg.enabledEndpoints || []).forEach(k => {
+                    const box = document.querySelector(
+                        `.ep-checkbox[data-tenant="${t.TenantId}"][value="${k}"]`
                     );
-                    if (freqSel && cfg.freq) freqSel.value = cfg.freq;
-
-                    const timeInp = document.querySelector(
-                        `.time-input[data-tenant="${t.TenantId}"]`
-                    );
-                    if (timeInp && cfg.time) timeInp.value = cfg.time;
-
-                } catch { }
-            });
-
-            /* persist schedule */
-            qsa('button[name="tenantId"]').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const tid = btn.value;
-
-                    const freqSel = document.querySelector(
-                        `.freq-select[data-tenant="${tid}"]`
-                    );
-                    const timeInp = document.querySelector(
-                        `.time-input[data-tenant="${tid}"]`
-                    );
-
-                    const cfg = {
-                        selected: qsa(`.ep-checkbox[data-tenant="${tid}"]:checked`)
-                            .map(cb => cb.value),
-                        freq: freqSel ? freqSel.value : '',
-                        time: timeInp ? timeInp.value : ''
-                    };
-
-                    localStorage.setItem(`pollConf_${tid}`, JSON.stringify(cfg));
+                    if (box) box.checked = true;
                 });
+
+                const freqSel = document.querySelector(
+                    `.freq-select[data-tenant="${t.TenantId}"]`
+                );
+                if (freqSel && cfg.pollingSchedule) freqSel.value = cfg.pollingSchedule;
+
+                const timeInp = document.querySelector(
+                    `.time-input[data-tenant="${t.TenantId}"]`
+                );
+                if (timeInp && cfg.runTime) timeInp.value = cfg.runTime;
             });
 
         })();


### PR DESCRIPTION
## Summary
- persist polling schedules via `backendutils.polling_settings`
- expose polling settings through a dedicated service
- load existing settings in polling configuration UI
- save new schedules to Postgres when "Save Schedule" is pressed

## Testing
- `dotnet test XeroNetStandardApp.Tests/XeroNetStandardApp.Tests.csproj` *(fails: dotnet not found)*