### PR TITLE
Enable scheduled polling via new background service

### DIFF
--- a/XeroNetStandardApp/Program.cs
+++ b/XeroNetStandardApp/Program.cs
@@ -25,6 +25,10 @@ builder.Services.AddDistributedMemoryCache();
 builder.Services.AddScoped<IPollingService, PollingService>();
 builder.Services.AddScoped<ICallLogService, CallLogService>();
 builder.Services.AddScoped<IPollingSettingsService, PollingSettingsService>();
+if (builder.Configuration.GetValue<bool>("EnablePollingScheduler"))
+{
+    builder.Services.AddHostedService<PollingScheduler>();
+}
 builder.Services.AddSession();
 builder.Services.AddMvc(options => options.EnableEndpointRouting = false);
 builder.Services.AddDataProtection()

--- a/XeroNetStandardApp/Program.cs
+++ b/XeroNetStandardApp/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 using Xero.NetStandard.OAuth2.Config;
 using XeroNetStandardApp.Models;
 using XeroNetStandardApp.Services;

--- a/XeroNetStandardApp/Services/IPollingSettingsService.cs
+++ b/XeroNetStandardApp/Services/IPollingSettingsService.cs
@@ -9,6 +9,7 @@ namespace XeroNetStandardApp.Services
     {
         Task<PollingSetting?> GetAsync(Guid organisationId);
         Task<IReadOnlyDictionary<Guid, PollingSetting>> GetManyAsync(IEnumerable<Guid> organisationIds);
+        Task<IReadOnlyList<PollingSetting>> GetAllAsync();
         Task UpsertAsync(Guid organisationId, string schedule, TimeSpan? runTime, IEnumerable<string> endpoints);
     }
 }

--- a/XeroNetStandardApp/Services/PollingScheduler.cs
+++ b/XeroNetStandardApp/Services/PollingScheduler.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace XeroNetStandardApp.Services
+{
+    /// <summary>
+    /// Background service that periodically checks the polling_settings table
+    /// and triggers polling runs when due.
+    /// </summary>
+    public class PollingScheduler : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<PollingScheduler> _log;
+        private readonly string _connString;
+
+        public PollingScheduler(IServiceScopeFactory scopeFactory,
+                                 ILogger<PollingScheduler> log,
+                                 IConfiguration cfg)
+        {
+            _scopeFactory = scopeFactory;
+            _log = log;
+            _connString = cfg.GetConnectionString("Postgres")
+                           ?? Environment.GetEnvironmentVariable("POSTGRES_CONN_STRING")
+                           ?? throw new InvalidOperationException("Postgres conn string missing");
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await RunScheduledPollsAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Error running polling scheduler");
+                }
+
+                // Check once per minute
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+
+        private async Task RunScheduledPollsAsync(CancellationToken ct)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var settingsSvc = scope.ServiceProvider.GetRequiredService<IPollingSettingsService>();
+            var pollingSvc = scope.ServiceProvider.GetRequiredService<IPollingService>();
+            var tokenSvc = scope.ServiceProvider.GetRequiredService<TokenService>();
+
+            var token = tokenSvc.RetrieveToken();
+            if (token?.Tenants == null || token.Tenants.Count == 0)
+                return; // nothing to poll
+
+            var activeTenants = token.Tenants
+                                     .Select(t => t.TenantId.ToString())
+                                     .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var settings = await settingsSvc.GetAllAsync();
+            var now = DateTimeOffset.UtcNow;
+
+            foreach (var cfg in settings)
+            {
+                if (!activeTenants.Contains(cfg.OrganisationId.ToString()))
+                    continue; // we don't have a token for this org
+
+                if (string.Equals(cfg.PollingSchedule, "Off", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var dueTime = new DateTimeOffset(now.Date + (cfg.RunTime ?? TimeSpan.Zero), TimeSpan.Zero);
+                if (string.Equals(cfg.PollingSchedule, "Weekly", StringComparison.OrdinalIgnoreCase) &&
+                    now.DayOfWeek != DayOfWeek.Monday)
+                    continue;
+
+                var lastRun = await GetLastRunAsync(cfg.OrganisationId);
+                if (now >= dueTime && (lastRun == null || lastRun < dueTime))
+                {
+                    foreach (var ep in cfg.EnabledEndpoints)
+                    {
+                        await pollingSvc.RunEndpointAsync(cfg.OrganisationId.ToString(), ep, now);
+                    }
+                }
+            }
+        }
+
+        private async Task<DateTimeOffset?> GetLastRunAsync(Guid organisationId)
+        {
+            const string sql = "SELECT MAX(call_time) FROM utils.api_call_log WHERE organisation_id = @OrgId;";
+            await using var conn = new NpgsqlConnection(_connString);
+            var dt = await conn.ExecuteScalarAsync<DateTime?>(sql, new { OrgId = organisationId });
+            return dt == null ? null : new DateTimeOffset(dt.Value, TimeSpan.Zero);
+        }
+    }
+}

--- a/XeroNetStandardApp/Services/PollingSettingsService.cs
+++ b/XeroNetStandardApp/Services/PollingSettingsService.cs
@@ -48,6 +48,18 @@ namespace XeroNetStandardApp.Services
             return list.ToDictionary(p => p.OrganisationId);
         }
 
+        public async Task<IReadOnlyList<PollingSetting>> GetAllAsync()
+        {
+            const string sql = @"SELECT organisation_id AS OrganisationId,
+                                         polling_schedule AS PollingSchedule,
+                                         run_time AS RunTime,
+                                         enabled_endpoints AS EnabledEndpoints
+                                    FROM backendutils.polling_settings;";
+            await using var conn = new NpgsqlConnection(_connString);
+            var list = await conn.QueryAsync<PollingSetting>(sql);
+            return list.AsList();
+        }
+
         public async Task UpsertAsync(Guid organisationId, string schedule, TimeSpan? runTime, IEnumerable<string> endpoints)
         {
             const string sql = @"INSERT INTO backendutils.polling_settings


### PR DESCRIPTION
## Summary
- introduce `PollingScheduler` background service to run saved schedules
- extend `IPollingSettingsService` with `GetAllAsync`
- implement fetching all settings in `PollingSettingsService`
- register scheduler when `EnablePollingScheduler` config flag is true

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*