### PR TITLE
Fix nullability warnings

### DIFF
--- a/XeroNetStandardApp.Tests/XeroNetStandardApp.Tests.csproj
+++ b/XeroNetStandardApp.Tests/XeroNetStandardApp.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/XeroNetStandardApp/Controllers/AuthorizationController.cs
+++ b/XeroNetStandardApp/Controllers/AuthorizationController.cs
@@ -86,7 +86,7 @@ namespace XeroNetStandardApp.Controllers
         public async Task<IActionResult> Disconnect([FromQuery] string tenantId)
         {
             var token = await GetValidXeroTokenAsync();
-            if (token == null || token.Tenants?.Count == 0)
+            if (token == null || token.Tenants == null || token.Tenants.Count == 0)
                 return BadRequest("No connected Xero organisation to disconnect.");
 
             var tenant = token.Tenants.FirstOrDefault(t =>

--- a/XeroNetStandardApp/Controllers/BaseXeroOAuth2Controller.cs
+++ b/XeroNetStandardApp/Controllers/BaseXeroOAuth2Controller.cs
@@ -105,6 +105,11 @@ namespace XeroNetStandardApp.Controllers
             {
                 // Double-check in case another request refreshed while we waited
                 token = _tokenService.RetrieveToken();
+                if (token == null)
+                {
+                    _logger.LogWarning("Token disappeared during refresh attempt.");
+                    return null;
+                }
                 expiryCutoffUtc = token.ExpiresAtUtc - _expiryBuffer;
                 if (DateTime.UtcNow < expiryCutoffUtc)
                 {

--- a/XeroNetStandardApp/Services/XeroRawIngestService.cs
+++ b/XeroNetStandardApp/Services/XeroRawIngestService.cs
@@ -175,7 +175,7 @@ namespace XeroNetStandardApp.Services
                                  ? endpoint.Status
                                  : new[] { (string?)null };
 
-                foreach (var status in statusList)
+                foreach (var status in statusList ?? Array.Empty<string?>())
                     rows += await IngestForOneStatusAsync(http, conn, endpoint, tenantId, table, status, since);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- handle missing tenants when disconnecting
- check refreshed token after awaiting lock
- guard against null `Status` list in raw ingest service
- enable nullable reference types for test project

## Testing
- `dotnet build` *(fails: `dotnet` not found)*