### PR TITLE
Fix nullability warning in tests

### DIFF
--- a/XeroNetStandardApp.Tests/PollingServiceTests.cs
+++ b/XeroNetStandardApp.Tests/PollingServiceTests.cs
@@ -38,7 +38,12 @@ namespace XeroNetStandardApp.Tests
             });
 
             var cfg = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
-                .AddInMemoryCollection(new[] { new System.Collections.Generic.KeyValuePair<string,string>("ConnectionStrings:Postgres", "Host=localhost") })
+                .AddInMemoryCollection(new[]
+                {
+                    new System.Collections.Generic.KeyValuePair<string, string?>(
+                        "ConnectionStrings:Postgres",
+                        "Host=localhost")
+                })
                 .Build();
 
             var svc = new PollingService(tokenService, raw, NullLogger<PollingService>.Instance, cfg);


### PR DESCRIPTION
## Summary
- update `AddInMemoryCollection` call in PollingServiceTests to use nullable string value

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*